### PR TITLE
feature: required keyword from koa route config to swagger config

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,10 @@ module.exports = exports = function parse (schema, existingDefinitions) {
 		return false;
 	}
 
+    if (get(schema, '_flags.presence') === 'required') {
+        swagger.required = true;
+    }
+
 	return { swagger, definitions };
 };
 


### PR DESCRIPTION
模块对 joi required 的处理缺失，没有将 required 信息返回给 swagger，望 merge 一下。

现在的版本：
![image](https://user-images.githubusercontent.com/3390062/46255527-99f4d080-c4d0-11e8-967c-1ead4fdc549a.png)

更新后的版本：
![image](https://user-images.githubusercontent.com/3390062/46255516-73369a00-c4d0-11e8-97af-b3bacc2eef19.png)
